### PR TITLE
[bugfix] Fixed error in iglu::mage(., return_type='df')

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iglu
 Type: Package
 Title: Interpreting Glucose Data from Continuous Glucose Monitors
-Version: 4.2.0
+Version: 4.2.1
 Authors@R: c(person("Elizabeth", "Chun",
             role = c("aut")),
             person("Steve", "Broll",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# iglu 4.2.1
+* Fixed bug in MAGE
+
 # iglu 4.2.0
 * Fixed bug in GRI calculation
 

--- a/R/mage.R
+++ b/R/mage.R
@@ -39,6 +39,7 @@
 #' @examples
 #' data(example_data_5_subject)
 #' mage(example_data_5_subject, version = 'ma')
+#' mage(example_data_5_subject, return_type='df')
 
 mage <- function(data,
                  version = c('ma', 'naive'),
@@ -87,7 +88,11 @@ mage_ma <- function(data,
                                     title = title, xlab = xlab, ylab = ylab, show_ma = show_ma, show_excursions = show_excursions, static_or_gui='ggplot'))
 
   # Check if a ggplot or number in list is returned - convert the latter to a number
-  if(class(out$MAGE[[1]])[1] == "numeric" | is.na(out$MAGE[[1]][1])) {
+  if(class(out$MAGE[[1]])[1] == "data.frame") {
+    # No processing on DataFrames is needed
+    out <- out
+  }
+  else if(class(out$MAGE[[1]])[1] == "numeric" | is.na(out$MAGE[[1]][1])) {
     out <- out %>% dplyr::mutate(MAGE = as.numeric(MAGE))
   }
   # else must be ggplot output

--- a/man/mage.Rd
+++ b/man/mage.Rd
@@ -79,6 +79,7 @@ If version \code{'ma'} is selected, the function computationally emulates the ma
 \examples{
 data(example_data_5_subject)
 mage(example_data_5_subject, version = 'ma')
+mage(example_data_5_subject, return_type='df')
 }
 \references{
 Service et al. (1970) Mean amplitude of glycemic excursions, a measure of diabetic instability


### PR DESCRIPTION
[bugfix] Fixed error in `iglu::mage(., return_type='df')`

When the DF was being returned from `iglu::mage_ma_single`, it was being passed into `is.na` which throws an error.