### PR TITLE
bugfix: match.arg was not working in the Shiny App for Mage plot

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# iglu 4.2.2
+* Fixed bug in Shiny app where MAGE plot was not rendering
+
 # iglu 4.2.1
 * Fixed bug in MAGE
 

--- a/R/mage.R
+++ b/R/mage.R
@@ -47,7 +47,7 @@ mage <- function(data,
                  short_ma = 5, long_ma = 32,
                  return_type = c('num', 'df'),
                  direction = c('avg', 'service', 'max', 'plus', 'minus'),
-                tz = "", inter_gap = 45,
+                 tz = "", inter_gap = 45,
                  max_gap=180,
                  plot = FALSE, title = NA, xlab = NA, ylab = NA, show_ma = FALSE, show_excursions = TRUE) {
 

--- a/R/mage_ma_single.R
+++ b/R/mage_ma_single.R
@@ -377,7 +377,7 @@ mage_ma_single <- function(data,
   if(plot) {
     # 6.1 Label 'Peaks' and 'Nadirs'
     direction = match.arg(direction, c('avg', 'service', 'max', 'plus', 'minus'))
-    static_or_gui = match.arg(static_or_gui, c('ggplot', 'plotly'))
+    static_or_gui = match.arg(static_or_gui, c('plotly', 'ggplot'))
 
     if (direction == 'avg') {
       tp_indexes <- dplyr::select(all_tp_indexes, idx, peak_or_nadir, plus_or_minus)

--- a/inst/shiny_iglu/server.R
+++ b/inst/shiny_iglu/server.R
@@ -583,7 +583,6 @@ shinyServer(function(input, output) {
     }
     else if(parameter_type == "all_metrics") {
       string = paste0("iglu::", input$metric, "(data, , , , , , '", input$parameter , "')")
-      print(string)
     }
     else if(parameter_type == 'pgs'){
       string = paste0('iglu::', input$metric, '(data, ', input$parameter, ', ', input$parameter2, ')')
@@ -877,8 +876,7 @@ shinyServer(function(input, output) {
 
       string = paste0("iglu::mage_ma_single(data=data,plot=TRUE,short_ma=",input$mage_short_ma,",long_ma=",
                       input$mage_long_ma,", direction='", input$direction, "', max_gap='", input$max_gap,
-                      "', show_ma=", input$mage_show_ma,", show_excursions=", input$show_excursions, ",title=",mage_title,",xlab=", mage_xlab,",ylab=",mage_ylab,")")
-
+                      "', show_ma=", input$mage_show_ma,", show_excursions=", input$show_excursions, ",title=",mage_title,",xlab=", mage_xlab,",ylab=",mage_ylab,",static_or_gui='ggplot')")
       eval(parse(text=string))
     }
   })


### PR DESCRIPTION
As seen in the image below (or [here](https://irinagain.shinyapps.io/shiny_iglu/)), the MAGE plot is not working for the Shiny app. This is due to the `match.arg` failing for the parameter `static_or_gui`.

The fix is a simple one-liner.

<img width="1065" alt="Screenshot 2025-03-05 at 6 07 01 PM" src="https://github.com/user-attachments/assets/2f2032a8-c384-4ab5-b0c1-74b9912afa74" />
